### PR TITLE
feat: added option to remove elements before parsing HTML

### DIFF
--- a/nodes/CheerioParser/CheerioParser.node.test.ts
+++ b/nodes/CheerioParser/CheerioParser.node.test.ts
@@ -52,7 +52,7 @@ describe("CheerioParser", () => {
     it("should have required properties", () => {
       const properties = node.description.properties;
       expect(properties).toBeDefined();
-      expect(properties.length).toBe(2);
+      expect(properties.length).toBe(3);
 
       // HTML input property
       const htmlProp = properties[0];
@@ -63,6 +63,11 @@ describe("CheerioParser", () => {
       const selectorsProp = properties[1];
       expect(selectorsProp.name).toBe("selectors");
       expect(selectorsProp.type).toBe("fixedCollection");
+
+      // Remove Elements property
+      const removeElementsProp = properties[2];
+      expect(removeElementsProp.name).toBe("removeElements");
+      expect(removeElementsProp.type).toBe("string");
     });
   });
 

--- a/nodes/CheerioParser/CheerioParser.node.test.ts
+++ b/nodes/CheerioParser/CheerioParser.node.test.ts
@@ -324,7 +324,8 @@ describe("CheerioParser", () => {
     it("should remove unwanted elements before parsing", async () => {
       const context = {
         getNodeParameter: (param: string, _itemIndex: number) => {
-          if (param === "html") return `\n        <html>\n          <body>\n            <script>console.log('bad')</script>\n            <style>.hidden{}</style>\n            <nav>Navigation</nav>\n            <footer>Footer</footer>\n            <div class='main'>Content</div>\n          </body>\n        </html>\n      `;
+          if (param === "html")
+            return `\n        <html>\n          <body>\n            <script>console.log('bad')</script>\n            <style>.hidden{}</style>\n            <nav>Navigation</nav>\n            <footer>Footer</footer>\n            <div class='main'>Content</div>\n          </body>\n        </html>\n      `;
           if (param === "selectors.selectorValues") {
             return [
               {
@@ -364,7 +365,8 @@ describe("CheerioParser", () => {
     it("should do nothing if removeElements is empty", async () => {
       const context = {
         getNodeParameter: (param: string, _itemIndex: number) => {
-          if (param === "html") return `\n        <html>\n          <body>\n            <script>console.log('bad')</script>\n            <div class='main'>Content</div>\n          </body>\n        </html>\n      `;
+          if (param === "html")
+            return `\n        <html>\n          <body>\n            <script>console.log('bad')</script>\n            <div class='main'>Content</div>\n          </body>\n        </html>\n      `;
           if (param === "selectors.selectorValues") {
             return [
               {

--- a/nodes/CheerioParser/CheerioParser.node.ts
+++ b/nodes/CheerioParser/CheerioParser.node.ts
@@ -128,12 +128,6 @@ export class CheerioParser implements INodeType {
           i,
           [],
         ) as SelectorItem[];
-        const removeElements = (
-          this.getNodeParameter("removeElements", i, "") as string
-        )
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean);
 
         if (selectorsData.length === 0) {
           throw new NodeOperationError(
@@ -142,9 +136,16 @@ export class CheerioParser implements INodeType {
           );
         }
 
+        const removeElements =
+          ((this.getNodeParameter("removeElements", i, "") as string) ?? "")
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean) ?? [];
+
         const $ = cheerio.load(html);
-        if (removeElements.length > 0) {
-          $(removeElements.join(", ")).remove();
+        if (Array.isArray(removeElements) && removeElements.length > 0) {
+          const selectorsToRemove = removeElements.join(", ");
+          $(selectorsToRemove).remove();
         }
         const results: { [key: string]: string | string[] } = {};
         let totalElements = 0;

--- a/nodes/CheerioParser/CheerioParser.node.ts
+++ b/nodes/CheerioParser/CheerioParser.node.ts
@@ -128,11 +128,9 @@ export class CheerioParser implements INodeType {
           i,
           [],
         ) as SelectorItem[];
-        const removeElements = (this.getNodeParameter(
-          "removeElements",
-          i,
-          ""
-        ) as string)
+        const removeElements = (
+          this.getNodeParameter("removeElements", i, "") as string
+        )
           .split(",")
           .map((s) => s.trim())
           .filter(Boolean);

--- a/nodes/CheerioParser/CheerioParser.node.ts
+++ b/nodes/CheerioParser/CheerioParser.node.ts
@@ -101,6 +101,16 @@ export class CheerioParser implements INodeType {
         ],
         description: "The CSS selectors to use",
       },
+      {
+        displayName: "Remove Elements",
+        name: "removeElements",
+        type: "string",
+        default: "",
+        placeholder: "script, style, nav, footer",
+        description:
+          "Comma-separated CSS selectors for elements to remove before parsing (e.g. 'script, style, nav, footer')",
+        required: false,
+      },
     ],
   };
 
@@ -118,6 +128,14 @@ export class CheerioParser implements INodeType {
           i,
           [],
         ) as SelectorItem[];
+        const removeElements = (this.getNodeParameter(
+          "removeElements",
+          i,
+          ""
+        ) as string)
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
 
         if (selectorsData.length === 0) {
           throw new NodeOperationError(
@@ -127,6 +145,9 @@ export class CheerioParser implements INodeType {
         }
 
         const $ = cheerio.load(html);
+        if (removeElements.length > 0) {
+          $(removeElements.join(", ")).remove();
+        }
         const results: { [key: string]: string | string[] } = {};
         let totalElements = 0;
 


### PR DESCRIPTION
Introduces a 'Remove Elements' parameter to Cheerio Parser, allowing users to specify CSS selectors for elements to remove from the HTML before parsing. Includes tests to verify that unwanted elements are removed or retained based on the parameter value.